### PR TITLE
Traverse page, doktype

### DIFF
--- a/Configuration/TSconfig/ContentElementWizard.tsconfig
+++ b/Configuration/TSconfig/ContentElementWizard.tsconfig
@@ -1,4 +1,4 @@
-[page["doktype"] == 183]
+[traverse(page, "doktype") == 183]
 TCEFORM.tt_content.list_type {
     removeItems = cartproducts_products
 }


### PR DESCRIPTION
The `[page["doktype"] == 183]` throws a warning in BE